### PR TITLE
Add Required Parameters to ExpressionParameters

### DIFF
--- a/Assets/VRCFaceTracking/Tools/Binary Parameter Tool/Editor/ParameterGenerator.cs
+++ b/Assets/VRCFaceTracking/Tools/Binary Parameter Tool/Editor/ParameterGenerator.cs
@@ -1,12 +1,50 @@
-﻿using System.Collections;
+using System;
 using System.Collections.Generic;
+using System.Linq;
+using UnityEditor;
 using UnityEditor.Animations;
 using UnityEngine;
+using VRC.SDK3.Avatars.Components;
+using VRC.SDK3.Avatars.ScriptableObjects;
 
 namespace VRCFaceTracking.EditorTools
 {
     public class ParameterTools
     {
+        public static bool AddVRCParameter(VRCAvatarDescriptor avatarDescriptor, List<VRCExpressionParameters.Parameter> parameters)
+        {
+            // Make sure Parameters aren't null
+            if (avatarDescriptor.expressionParameters == null)
+            {
+                Debug.LogWarning("ExpressionsParameters not found!");
+                return false;
+            }
+            // Instantiate and Save to Database
+            VRCExpressionParameters newParameters = avatarDescriptor.expressionParameters;
+            string assetPath = AssetDatabase.GetAssetPath(avatarDescriptor.expressionParameters);
+            if (assetPath != String.Empty)
+            {
+                AssetDatabase.RemoveObjectFromAsset(avatarDescriptor.expressionParameters);
+                AssetDatabase.CreateAsset(newParameters, assetPath);
+                avatarDescriptor.expressionParameters = newParameters;
+            }
+
+            foreach (VRCExpressionParameters.Parameter parameter in parameters)
+            {
+                // Make sure the parameter doesn't already exist
+                VRCExpressionParameters.Parameter foundParameter = newParameters.FindParameter(parameter.name);
+                if (foundParameter == null || foundParameter.valueType != parameter.valueType)
+                {
+                    // Add the parameter
+                    List<VRCExpressionParameters.Parameter> betterParametersBecauseItsAListInstead =
+                        newParameters.parameters.ToList();
+                    betterParametersBecauseItsAListInstead.Add(parameter);
+                    newParameters.parameters = betterParametersBecauseItsAListInstead.ToArray();
+                }
+            }
+            return true;
+        }
+        
         public static void CheckAndCreateParameter(string name, AnimatorController animatorController, int type)
         {
             AnimatorControllerParameterType _typeEnum = (AnimatorControllerParameterType)type;


### PR DESCRIPTION
Just a quick little snippet of code from my other project that will add a Parameter to an avatar's expressionParameters

> ___
> ## ⚠️ WARNING ⚠️
> 
> This is only a method! This PR itself will **NOT** change anything!
> 
> I am unaware of how the codebase works, so I just left the method here for you to design with your code.
> 
> ___

Essentially, all you need to do is pass through the GameObject's VRCAvatarDescriptor (SDK3, not SDKBase!), then a List of Parameters to add. The following is an example of a bool parameter called `isAzmidiCool`, which defaults to `true`, and is saved:

```csharp
VRCExpressionParameters.Parameter azmidiParameter = new VRCExpressionParameters.Parameter
{
    name = "isAzmidiCool",
    defaultValue = 1f,
    saved = true,
    valueType = VRCExpressionParameters.ValueType.Bool
}
```

then, push all parameters to a list (even if there's only one)

```csharp
List<VRCExpressionParameters.Parameter> parametersList = new List<VRCExpressionParameters.Parameter>
{
    azmidiParameter
}
```
(or with `List<T>.Add()`)

finally, pass that through to the `ParameterTools.AddVRCParameter(VRCAvatarDescriptor, List<VRCExpressionParameters.Parameter>)`

```csharp
ParameterTools.AddVRCParameter(avatarDescriptor, parametersList)
```

Done!

> ___
> ## 📝 NOTE📝
> Don't run this in a loop with only one parameter. It needs to cache the AvatarDescriptor's parameters, delete the SerializableObject (from the Assets folder), create a new one, then write it to the Assets folder. This has to be done for it to save properly and not corrupt.
> ___