### PR TITLE
Improve "Create" button behavior 

### DIFF
--- a/Assets/VRCFaceTracking/Tools/Binary Parameter Tool/Editor/BinaryParameterWindow.cs
+++ b/Assets/VRCFaceTracking/Tools/Binary Parameter Tool/Editor/BinaryParameterWindow.cs
@@ -494,12 +494,6 @@ namespace VRCFaceTracking.EditorTools
                         // no smoothing layer
                         if (_tab == 0 && !_smooth)
                         {
-                            // remove only the float parameter from the VRC avatar parameter list
-                            ParameterTools.RemoveVRCParameter(_avDescriptor, new VRCExpressionParameters.Parameter
-                            {
-                                name = _baseParamName,
-                                valueType = VRCExpressionParameters.ValueType.Float
-                            });
                             // create parameter in the animation controller
                             ParameterTools.CheckAndCreateParameter(_baseParamName, _animatorController, 1);
 
@@ -510,12 +504,6 @@ namespace VRCFaceTracking.EditorTools
                         // with smoothing layer
                         else if (_tab == 0)
                         {
-                            // remove only the float parameter from the VRC avatar parameter list
-                            ParameterTools.RemoveVRCParameter(_avDescriptor, new VRCExpressionParameters.Parameter
-                            {
-                                name = _baseParamName,
-                                valueType = VRCExpressionParameters.ValueType.Float
-                            });
                             // create parameter in the animation controller
                             ParameterTools.CheckAndCreateParameter(_baseParamName, _animatorController, 1);
 

--- a/Assets/VRCFaceTracking/Tools/Binary Parameter Tool/Editor/BinaryParameterWindow.cs
+++ b/Assets/VRCFaceTracking/Tools/Binary Parameter Tool/Editor/BinaryParameterWindow.cs
@@ -409,6 +409,13 @@ namespace VRCFaceTracking.EditorTools
                         {
                             if (_tab == 0 && !_smooth)
                             {
+                                // remove only the float parameter from the VRC avatar parameter list
+                                ParameterTools.RemoveVRCParameter(_avDescriptor, new VRCExpressionParameters.Parameter
+                                {
+                                    name = _baseParamName,
+                                    valueType = VRCExpressionParameters.ValueType.Float
+                                });
+                                // create parameter in the animation controller
                                 ParameterTools.CheckAndCreateParameter(_baseParamName, _animatorController, 1);
 
                                 _binaryStateMachine.initClip = BinaryParameterFloatDriver.CreateFloatDriverAnimation(_baseParamName, 0f);
@@ -416,6 +423,13 @@ namespace VRCFaceTracking.EditorTools
                             }
                             else if (_tab == 0)
                             {
+                                // remove only the float parameter from the VRC avatar parameter list
+                                ParameterTools.RemoveVRCParameter(_avDescriptor, new VRCExpressionParameters.Parameter
+                                {
+                                    name = _baseParamName,
+                                    valueType = VRCExpressionParameters.ValueType.Float
+                                });
+                                // create parameter in the animation controller
                                 ParameterTools.CheckAndCreateParameter(_baseParamName, _animatorController, 1);
 
                                 _binaryStateMachine.CreateSmoothingLayer(_smoothness);
@@ -423,14 +437,11 @@ namespace VRCFaceTracking.EditorTools
                                 _binaryStateMachine.initClip = BinaryParameterFloatDriver.CreateFloatDriverAnimation(_baseParamName + "Proxy", 0f);
                                 _binaryStateMachine.finalClip = BinaryParameterFloatDriver.CreateFloatDriverAnimation(_baseParamName + "Proxy", 1f);
                             }
-                            if (ParameterTools.AddVRCParameter(_avDescriptor, GenerateBinaryParams(_baseParamName, _binarySize, _isCombined)))
-                            {
-                                ParameterTools.RemoveVRCParameter(_avDescriptor, _baseParamName);
-                                _binaryStateMachine.CreateBinaryLayer();
-                            }
-                            else
-                                EditorGUILayout.HelpBox("Parameters can not fit, or Expressions Parameters do not exist.", MessageType.Warning);
+                            // generates direct binary layer if _tab==1
+                            _binaryStateMachine.CreateBinaryLayer();
                         }
+                        else
+                            EditorGUILayout.HelpBox("Parameters can not fit, or Expressions Parameters do not exist.", MessageType.Warning);
                     }
                 }
                 else if (GUILayout.Button
@@ -444,22 +455,32 @@ namespace VRCFaceTracking.EditorTools
                 {
                     if (ParameterTools.AddVRCParameter(_avDescriptor, GenerateBinaryParams(_baseParamName, _binarySize, _isCombined)) | !_createParametersInDescriptor)
                     {
+                        // float parameter and not smoothing
                         if (_tab == 0 && !_smooth)
                         {
+                            // remove only the float parameter from the VRC avatar parameter list
                             ParameterTools.RemoveVRCParameter(_avDescriptor, new VRCExpressionParameters.Parameter
                             {
                                 name = _baseParamName,
                                 valueType = VRCExpressionParameters.ValueType.Float
                             });
+                            // create parameter in the animation controller
                             ParameterTools.CheckAndCreateParameter(_baseParamName, _animatorController, 1);
 
                             _binaryStateMachine.initClip = BinaryParameterFloatDriver.CreateFloatDriverAnimation(_baseParamName, 0f);
                             _binaryStateMachine.finalClip = BinaryParameterFloatDriver.CreateFloatDriverAnimation(_baseParamName, 1f);
                             _binaryStateMachine.finalNegativeClip = BinaryParameterFloatDriver.CreateFloatDriverAnimation(_baseParamName, -1f);
                         }
+                        // float parameter and smoothing
                         else if (_tab == 0)
                         {
-                            ParameterTools.RemoveVRCParameter(_avDescriptor, _baseParamName);
+                            // remove only the float parameter from the VRC avatar parameter list
+                            ParameterTools.RemoveVRCParameter(_avDescriptor, new VRCExpressionParameters.Parameter
+                            {
+                                name = _baseParamName,
+                                valueType = VRCExpressionParameters.ValueType.Float
+                            });
+                            // create parameter in the animation controller
                             ParameterTools.CheckAndCreateParameter(_baseParamName, _animatorController, 1);
 
                             _binaryStateMachine.CreateSmoothingLayer(_smoothness);
@@ -467,6 +488,7 @@ namespace VRCFaceTracking.EditorTools
                             _binaryStateMachine.finalClip = BinaryParameterFloatDriver.CreateFloatDriverAnimation(_baseParamName + "Proxy", 1f);
                             _binaryStateMachine.finalNegativeClip = BinaryParameterFloatDriver.CreateFloatDriverAnimation(_baseParamName + "Proxy", -1f);
                         }
+                        // generates direct binary layer if _tab==1
                         _binaryStateMachine.CreateCombinedBinaryLayer();
                     }
                     else

--- a/Assets/VRCFaceTracking/Tools/Binary Parameter Tool/Editor/BinaryParameterWindow.cs
+++ b/Assets/VRCFaceTracking/Tools/Binary Parameter Tool/Editor/BinaryParameterWindow.cs
@@ -405,30 +405,44 @@ namespace VRCFaceTracking.EditorTools
                             "set animations, transitions, and parameters that handle the specified Binary Parameter."
                         )))
                     {
-                        if (ParameterTools.AddVRCParameter(_avDescriptor, GenerateBinaryParams(_baseParamName, _binarySize, _isCombined)) | !_createParametersInDescriptor)
+                        bool doAnimationControllerActions = true; 
+                        // creating parameters in VRC avatar parameters asset
+                        if (_createParametersInDescriptor)
                         {
+                            // remove original (float) parameter from VRC avatar parameters asset
+                            // won't remove if it isn't a float!
+                            ParameterTools.RemoveVRCParameter(_avDescriptor, new VRCExpressionParameters.Parameter
+                            {
+                                name = _baseParamName,
+                                valueType = VRCExpressionParameters.ValueType.Float
+                            }, true);
+
+                            if (!ParameterTools.AddVRCParameter(_avDescriptor, GenerateBinaryParams(_baseParamName, _binarySize, _isCombined)))
+                            {
+                                doAnimationControllerActions = false;
+                                // HelpBoxes don't actually show because they show in the time window of the buttonclick
+                                //EditorGUILayout.HelpBox("Parameters can not fit, or Expressions Parameters do not exist.", MessageType.Warning);
+                                EditorUtility.DisplayDialog("Warning", "Parameters can not fit, or Expressions Parameters do not exist.\n" +
+                                    "Aborting binary parameter creation.", "OK");
+                            }
+                        }
+
+                        // animation controller actions
+                        // don't add to animation controller if adding to VRC parameters asset failed
+                        if (doAnimationControllerActions)
+                        {
+                            // no smoothing layer
                             if (_tab == 0 && !_smooth)
                             {
-                                // remove only the float parameter from the VRC avatar parameter list
-                                ParameterTools.RemoveVRCParameter(_avDescriptor, new VRCExpressionParameters.Parameter
-                                {
-                                    name = _baseParamName,
-                                    valueType = VRCExpressionParameters.ValueType.Float
-                                });
                                 // create parameter in the animation controller
                                 ParameterTools.CheckAndCreateParameter(_baseParamName, _animatorController, 1);
 
                                 _binaryStateMachine.initClip = BinaryParameterFloatDriver.CreateFloatDriverAnimation(_baseParamName, 0f);
                                 _binaryStateMachine.finalClip = BinaryParameterFloatDriver.CreateFloatDriverAnimation(_baseParamName, 1f);
                             }
+                            // with smoothing layer
                             else if (_tab == 0)
                             {
-                                // remove only the float parameter from the VRC avatar parameter list
-                                ParameterTools.RemoveVRCParameter(_avDescriptor, new VRCExpressionParameters.Parameter
-                                {
-                                    name = _baseParamName,
-                                    valueType = VRCExpressionParameters.ValueType.Float
-                                });
                                 // create parameter in the animation controller
                                 ParameterTools.CheckAndCreateParameter(_baseParamName, _animatorController, 1);
 
@@ -440,8 +454,6 @@ namespace VRCFaceTracking.EditorTools
                             // generates direct binary layer if _tab==1
                             _binaryStateMachine.CreateBinaryLayer();
                         }
-                        else
-                            EditorGUILayout.HelpBox("Parameters can not fit, or Expressions Parameters do not exist.", MessageType.Warning);
                     }
                 }
                 else if (GUILayout.Button
@@ -453,9 +465,33 @@ namespace VRCFaceTracking.EditorTools
                         "set animations, transitions, and parameters that handle the specified Combined Binary Parameter."
                     )))
                 {
-                    if (ParameterTools.AddVRCParameter(_avDescriptor, GenerateBinaryParams(_baseParamName, _binarySize, _isCombined)) | !_createParametersInDescriptor)
+                    bool doAnimationControllerActions = true;
+                    // creating parameters in VRC avatar parameters asset
+                    if (_createParametersInDescriptor)
                     {
-                        // float parameter and not smoothing
+                        // remove original (float) parameter from VRC avatar parameters asset
+                        // won't remove if it isn't a float!
+                        ParameterTools.RemoveVRCParameter(_avDescriptor, new VRCExpressionParameters.Parameter
+                        {
+                            name = _baseParamName,
+                            valueType = VRCExpressionParameters.ValueType.Float
+                        }, true);
+
+                        if (!ParameterTools.AddVRCParameter(_avDescriptor, GenerateBinaryParams(_baseParamName, _binarySize, _isCombined)))
+                        {
+                            doAnimationControllerActions = false;
+                            // HelpBoxes don't actually show because they show in the time window of the buttonclick
+                            //EditorGUILayout.HelpBox("Parameters can not fit, or Expressions Parameters do not exist.", MessageType.Warning);
+                            EditorUtility.DisplayDialog("Warning", "Parameters can not fit, or Expressions Parameters do not exist.\n" +
+                                "Aborting binary parameter creation.", "OK");
+                        }
+                    }
+
+                    // animation controller actions
+                    // don't add to animation controller if adding to VRC parameters asset failed
+                    if (doAnimationControllerActions)
+                    {
+                        // no smoothing layer
                         if (_tab == 0 && !_smooth)
                         {
                             // remove only the float parameter from the VRC avatar parameter list
@@ -471,7 +507,7 @@ namespace VRCFaceTracking.EditorTools
                             _binaryStateMachine.finalClip = BinaryParameterFloatDriver.CreateFloatDriverAnimation(_baseParamName, 1f);
                             _binaryStateMachine.finalNegativeClip = BinaryParameterFloatDriver.CreateFloatDriverAnimation(_baseParamName, -1f);
                         }
-                        // float parameter and smoothing
+                        // with smoothing layer
                         else if (_tab == 0)
                         {
                             // remove only the float parameter from the VRC avatar parameter list
@@ -491,10 +527,11 @@ namespace VRCFaceTracking.EditorTools
                         // generates direct binary layer if _tab==1
                         _binaryStateMachine.CreateCombinedBinaryLayer();
                     }
-                    else
-                        EditorGUILayout.HelpBox("Parameters can not fit, or Expressions Parameters do not exist.", MessageType.Warning);
                 }
-                EditorGUILayout.HelpBox("Parameters (" + _avDescriptor.expressionParameters.CalcTotalCost() + "/" + VRCExpressionParameters.MAX_PARAMETER_COST + "):" + GenerateParamNames(_baseParamName, _binarySize, _isCombined), MessageType.None);
+                EditorGUILayout.Space(); 
+                EditorGUILayout.HelpBox("Parameters (" + _avDescriptor.expressionParameters.CalcTotalCost() + "/" + VRCExpressionParameters.MAX_PARAMETER_COST + ")\n\n" + 
+                    "Binary Parameters to create:" + (_createParametersInDescriptor ? "(Will Add to VRC Expression Parameters)" : "") + 
+                    GenerateParamNames(_baseParamName, _binarySize, _isCombined), MessageType.None);
 
             }
         }

--- a/Assets/VRCFaceTracking/Tools/Binary Parameter Tool/Editor/ParameterGenerator.cs
+++ b/Assets/VRCFaceTracking/Tools/Binary Parameter Tool/Editor/ParameterGenerator.cs
@@ -132,6 +132,41 @@ namespace VRCFaceTracking.EditorTools
             return true;
         }
 
+        public static bool RemoveVRCParameter(VRCAvatarDescriptor avatarDescriptor, string parameter)
+        {
+            // Make sure Parameters aren't null
+            if (avatarDescriptor.expressionParameters == null)
+            {
+                Debug.Log("ExpressionsParameters not found!");
+                return false;
+            }
+
+            // Instantiate and Save to Database
+            VRCExpressionParameters newParameters = avatarDescriptor.expressionParameters;
+            string assetPath = AssetDatabase.GetAssetPath(avatarDescriptor.expressionParameters);
+            if (assetPath != String.Empty)
+            {
+                AssetDatabase.RemoveObjectFromAsset(avatarDescriptor.expressionParameters);
+                AssetDatabase.CreateAsset(newParameters, assetPath);
+                avatarDescriptor.expressionParameters = newParameters;
+            }
+
+            // Check and see if parameter exists
+            if (newParameters.FindParameter(parameter) != null)
+            {
+                // Remove the parameters with listed keyword
+                List<VRCExpressionParameters.Parameter> betterParametersBecauseItsAListInstead =
+                    newParameters.parameters.ToList();
+
+                // Remove without editing the collection being looped
+                betterParametersBecauseItsAListInstead = 
+                    betterParametersBecauseItsAListInstead.Where(p => !p.name.Contains(parameter)).ToList(); 
+
+                newParameters.parameters = betterParametersBecauseItsAListInstead.ToArray();
+            }
+            return true;
+        }
+
         public static AnimatorControllerParameter CheckAndCreateParameter(string paramName, AnimatorController animatorController, int type, double defaultVal = 0)
         {
             AnimatorControllerParameter param = new AnimatorControllerParameter();

--- a/Assets/VRCFaceTracking/Tools/Binary Parameter Tool/Editor/ParameterGenerator.cs
+++ b/Assets/VRCFaceTracking/Tools/Binary Parameter Tool/Editor/ParameterGenerator.cs
@@ -17,14 +17,14 @@ namespace VRCFaceTracking.EditorTools
             int paramTotalCost = 0;
             int maxCost = VRCExpressionParameters.MAX_PARAMETER_COST;
 
-            paramTotalCost += avatarDescriptor.expressionParameters.CalcTotalCost();
-
             // Make sure Parameters aren't null
             if (avatarDescriptor.expressionParameters == null)
             {
                 Debug.Log("ExpressionsParameters not found!");
                 return false;
             }
+
+            paramTotalCost += avatarDescriptor.expressionParameters.CalcTotalCost();
 
             // Checks to see if parameter already exists; calculate new total parameter cost
             foreach (VRCExpressionParameters.Parameter param in parameters)
@@ -100,7 +100,7 @@ namespace VRCFaceTracking.EditorTools
             return true;
         }
 
-        public static bool RemoveVRCParameter(VRCAvatarDescriptor avatarDescriptor, VRCExpressionParameters.Parameter parameter)
+        public static bool RemoveVRCParameter(VRCAvatarDescriptor avatarDescriptor, VRCExpressionParameters.Parameter parameter, bool floatOnly=false)
         {
             // Make sure Parameters aren't null
             if (avatarDescriptor.expressionParameters == null)
@@ -121,8 +121,15 @@ namespace VRCFaceTracking.EditorTools
 
              // Check and see if parameter exists
             VRCExpressionParameters.Parameter foundParameter = newParameters.FindParameter(parameter.name);
-            if (newParameters.FindParameter(parameter.name) != null)
+            if (foundParameter != null)
             {
+                // is parameter not a float?
+                if (floatOnly && foundParameter.valueType != VRCExpressionParameters.ValueType.Float)
+                {
+                    Debug.Log("Tried to remove float parameter " + parameter.name + " but it was not a float. Ignoring");
+                    return false;
+                }
+
                 // Remove the parameter
                 List<VRCExpressionParameters.Parameter> betterParametersBecauseItsAListInstead =
                     newParameters.parameters.ToList();
@@ -132,7 +139,8 @@ namespace VRCFaceTracking.EditorTools
             return true;
         }
 
-        public static bool RemoveVRCParameter(VRCAvatarDescriptor avatarDescriptor, string parameter)
+        // kept for future use
+        public static bool RemoveVRCParametersByStem(VRCAvatarDescriptor avatarDescriptor, string parameterStem)
         {
             // Make sure Parameters aren't null
             if (avatarDescriptor.expressionParameters == null)
@@ -152,7 +160,7 @@ namespace VRCFaceTracking.EditorTools
             }
 
             // Check and see if parameter exists
-            if (newParameters.FindParameter(parameter) != null)
+            if (newParameters.FindParameter(parameterStem) != null)
             {
                 // Remove the parameters with listed keyword
                 List<VRCExpressionParameters.Parameter> betterParametersBecauseItsAListInstead =
@@ -160,7 +168,7 @@ namespace VRCFaceTracking.EditorTools
 
                 // Remove without editing the collection being looped
                 betterParametersBecauseItsAListInstead = 
-                    betterParametersBecauseItsAListInstead.Where(p => !p.name.Contains(parameter)).ToList(); 
+                    betterParametersBecauseItsAListInstead.Where(p => !p.name.Contains(parameterStem)).ToList(); 
 
                 newParameters.parameters = betterParametersBecauseItsAListInstead.ToArray();
             }


### PR DESCRIPTION
Various fixes to the behavior of the "Create" button, including fix for the "create parameter" toggle similar to Jerry's PR #9. This is a more comprehensive rewrite of that segment of code in BinaryParameterWindow.cs. Tool behavior should now be more logical across tool setting permutations. 

Also contains code not in the git branch but in the latest unity package release that causes a `Collection was modified enumeration operation may not execute` error. Code has since been fixed and renamed, but is currently not utilized. 