### PR TITLE
Tiered Naming Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -416,3 +416,4 @@ FodyWeavers.xsd
 /.vsconfig
 /Assets/VRCFaceTracking/Tools/Binary Parameter Tool/Editor/Test.controller
 /Assets/VRCFaceTracking/Tools/Binary Parameter Tool/Editor/AllParams.asset
+/Export

--- a/Assets/VRCFaceTracking/Tools/Binary Parameter Tool/Editor/BinaryParameterFloatDriver.cs
+++ b/Assets/VRCFaceTracking/Tools/Binary Parameter Tool/Editor/BinaryParameterFloatDriver.cs
@@ -22,11 +22,11 @@ namespace VRCFaceTracking.EditorTools
                 Directory.CreateDirectory("Assets/VRCFaceTracking/Generated/Anims/");
             }
 
-            string[] guid = (AssetDatabase.FindAssets(baseParamName + parameterValue + "Float"));
+            string[] guid = (AssetDatabase.FindAssets(NameNoSymbol(baseParamName) + parameterValue + "Float"));
 
             if (guid.Length == 0)
             {
-                AssetDatabase.CreateAsset(_animationClip, "Assets/VRCFaceTracking/Generated/Anims/" + baseParamName + parameterValue + "Float.anim");
+                AssetDatabase.CreateAsset(_animationClip, "Assets/VRCFaceTracking/Generated/Anims/" + NameNoSymbol(baseParamName) + parameterValue + "Float.anim");
                 AssetDatabase.SaveAssets();
             }
 
@@ -51,11 +51,11 @@ namespace VRCFaceTracking.EditorTools
                 Directory.CreateDirectory("Assets/VRCFaceTracking/Generated/Anims/");
             }
 
-            string[] guid = (AssetDatabase.FindAssets(animName));
+            string[] guid = (AssetDatabase.FindAssets(NameNoSymbol(animName)));
 
             if (guid.Length == 0)
             {
-                AssetDatabase.CreateAsset(_animationClip, "Assets/VRCFaceTracking/Generated/Anims/" + animName + ".anim");
+                AssetDatabase.CreateAsset(_animationClip, "Assets/VRCFaceTracking/Generated/Anims/" + NameNoSymbol(animName) + ".anim");
                 AssetDatabase.SaveAssets();
             }
 
@@ -83,11 +83,11 @@ namespace VRCFaceTracking.EditorTools
                 Directory.CreateDirectory("Assets/VRCFaceTracking/Generated/Anims/");
             }
 
-            string[] guid = (AssetDatabase.FindAssets(baseParamName + initThreshold + "Smoother.anim"));
+            string[] guid = (AssetDatabase.FindAssets(NameNoSymbol(baseParamName) + initThreshold + "Smoother.anim"));
 
             if (guid.Length == 0)
             {
-                AssetDatabase.CreateAsset(_animationClip1, "Assets/VRCFaceTracking/Generated/Anims/"+ baseParamName + initThreshold + "Smoother.anim");
+                AssetDatabase.CreateAsset(_animationClip1, "Assets/VRCFaceTracking/Generated/Anims/" + NameNoSymbol(baseParamName) + initThreshold + "Smoother.anim");
                 AssetDatabase.SaveAssets();
             }
 
@@ -100,7 +100,7 @@ namespace VRCFaceTracking.EditorTools
 
             if (guid.Length == 0)
             {
-                AssetDatabase.CreateAsset(_animationClip2, "Assets/VRCFaceTracking/Generated/Anims/" + baseParamName + finalThreshold + "Smoother.anim");
+                AssetDatabase.CreateAsset(_animationClip2, "Assets/VRCFaceTracking/Generated/Anims/" + NameNoSymbol(baseParamName) + finalThreshold + "Smoother.anim");
                 AssetDatabase.SaveAssets();
             }
 
@@ -110,6 +110,21 @@ namespace VRCFaceTracking.EditorTools
             }
 
             return new AnimationClip[] { _animationClip1, _animationClip2 };
+        }
+
+        public static string NameNoSymbol(string name)
+        {
+            string nameNoSym = "";
+
+            for (int j = 0; j < name.Length; j++)
+            {
+                if (name[j] != '/')
+                {
+                    nameNoSym += name[j];
+                }
+
+            }
+            return nameNoSym;
         }
     }
 }

--- a/Assets/VRCFaceTracking/Tools/Binary Parameter Tool/Editor/BinaryParameterScript.cs
+++ b/Assets/VRCFaceTracking/Tools/Binary Parameter Tool/Editor/BinaryParameterScript.cs
@@ -60,7 +60,7 @@ namespace VRCFaceTracking.EditorTools
 
             // Clear out existing ...Binary layers to make-way for an updated one
             for (int i = 0; i < animatorController.layers.Length; i++)
-                if (animatorController.layers[i].name == baseParamName + " Binary")
+                if (animatorController.layers[i].name == NameNoSymbol(baseParamName) + " Binary")
                 {
                     animatorController.RemoveLayer(i);
                 }
@@ -68,7 +68,7 @@ namespace VRCFaceTracking.EditorTools
             // Creating a layer object since the default weight can not be assigned after creation.
             AnimatorControllerLayer layer = new AnimatorControllerLayer
             {
-                name = baseParamName + " Binary",
+                name = NameNoSymbol(baseParamName) + " Binary",
                 stateMachine = new AnimatorStateMachine
                 {
                     hideFlags = HideFlags.HideInHierarchy
@@ -108,7 +108,7 @@ namespace VRCFaceTracking.EditorTools
 
             // Clear out existing ...Binary layers to make-way for an updated one
             for (int i = 0; i < animatorController.layers.Length; i++)
-                if (animatorController.layers[i].name == baseParamName + " Binary")
+                if (animatorController.layers[i].name == NameNoSymbol(baseParamName) + " Binary")
                 {
                     animatorController.RemoveLayer(i);
                 }
@@ -116,7 +116,7 @@ namespace VRCFaceTracking.EditorTools
             // Creating a layer object since the default weight can not be assigned after creation.
             AnimatorControllerLayer layer = new AnimatorControllerLayer
             {
-                name = baseParamName + " Binary",
+                name = NameNoSymbol(baseParamName) + " Binary",
                 stateMachine = new AnimatorStateMachine
                 {
                     hideFlags = HideFlags.HideInHierarchy
@@ -187,7 +187,7 @@ namespace VRCFaceTracking.EditorTools
 
             AnimatorState[] states = new AnimatorState[binarySteps];
 
-            stateMachine.name = name + " Binary State Machine";
+            stateMachine.name = NameNoSymbol(name) + " Binary State Machine";
             stateMachine.anyStatePosition = new Vector3(20, 0, 0);
             stateMachine.entryPosition = new Vector3
             (
@@ -228,7 +228,7 @@ namespace VRCFaceTracking.EditorTools
                 // Creating all the binary states and transitions
                 for (int i = 1; i < binarySteps; i++)
                 {
-                    states[i] = stateMachine.AddState(name + i * negativeCount, new Vector3
+                    states[i] = stateMachine.AddState(NameNoSymbol(name) + i * negativeCount, new Vector3
                     (
                         stateMachine.anyStatePosition.x - 20 - Mathf.Sin(((float)i / binarySteps) * Mathf.PI * (-1) * negativeCount) * (200 + binarySteps * 8),
                         stateMachine.anyStatePosition.y - 5 - Mathf.Cos(((float)i / binarySteps) * Mathf.PI) * (100 + binarySteps * 4),
@@ -263,7 +263,7 @@ namespace VRCFaceTracking.EditorTools
                         blendType = BlendTreeType.Simple1D,
                         hideFlags = HideFlags.HideInHierarchy,
                         blendParameter = "BinaryBlend",
-                        name = name + (i * negativeCount),
+                        name = NameNoSymbol(name) + (i * negativeCount),
                         useAutomaticThresholds = false
                     };
 
@@ -308,7 +308,7 @@ namespace VRCFaceTracking.EditorTools
             for (int i = 0; i < binarySteps; i++)
             {
 
-                stateMachine.name = name + " Binary State Machine";
+                stateMachine.name = NameNoSymbol(name) + " Binary State Machine";
                 stateMachine.anyStatePosition = new Vector3(20, 0, 0);
                 stateMachine.entryPosition = new Vector3
                 (
@@ -318,7 +318,7 @@ namespace VRCFaceTracking.EditorTools
                 );
 
 
-                states[i] = stateMachine.AddState(name + i, new Vector3
+                states[i] = stateMachine.AddState(NameNoSymbol(name) + i, new Vector3
                 (
                     stateMachine.anyStatePosition.x - 20 - Mathf.Sin((i / (float)binarySteps) * Mathf.PI * 2f) * (200 + binarySteps * 8),
                     stateMachine.anyStatePosition.y - 5 - Mathf.Cos((i / (float)binarySteps) * Mathf.PI * 2f) * (100 + binarySteps * 4),
@@ -349,7 +349,7 @@ namespace VRCFaceTracking.EditorTools
                     blendType = BlendTreeType.Simple1D,
                     hideFlags = HideFlags.HideInHierarchy,
                     blendParameter = "BinaryBlend",
-                    name = name + i,
+                    name = NameNoSymbol(name) + i,
                     useAutomaticThresholds = false,
                 };
 
@@ -381,7 +381,7 @@ namespace VRCFaceTracking.EditorTools
             int minSteps = (int)((min + .05) * binarySteps);
             int maxSteps = (int)((max - .05) * binarySteps);
 
-            stateMachine.name = name + " Binary State Machine";
+            stateMachine.name = NameNoSymbol(name) + " Binary State Machine";
             stateMachine.entryPosition = new Vector3(0, 20, 0);
             stateMachine.anyStatePosition = new Vector3
             (
@@ -418,7 +418,7 @@ namespace VRCFaceTracking.EditorTools
                     blendType = BlendTreeType.Simple1D,
                     hideFlags = HideFlags.HideInHierarchy,
                     blendParameter = "BinaryBlend",
-                    name = name + i,
+                    name = NameNoSymbol(name) + i,
                     useAutomaticThresholds = false,
                 };
 
@@ -500,7 +500,7 @@ namespace VRCFaceTracking.EditorTools
 
             // Clear out existing ...Binary layers to make-way for an updated one
             for (int i = 0; i < animatorController.layers.Length; i++)
-                if (animatorController.layers[i].name == baseParamName + " Float Smoother")
+                if (animatorController.layers[i].name == NameNoSymbol(baseParamName) + " Float Smoother")
                 {
                     animatorController.RemoveLayer(i);
                 }
@@ -508,7 +508,7 @@ namespace VRCFaceTracking.EditorTools
             // Creates an animation layer
             AnimatorControllerLayer layer = new AnimatorControllerLayer
             {
-                name = baseParamName + " Float Smoother",
+                name = NameNoSymbol(baseParamName) + " Float Smoother",
                 stateMachine = new AnimatorStateMachine
                 {
                     hideFlags = HideFlags.HideInHierarchy
@@ -570,6 +570,21 @@ namespace VRCFaceTracking.EditorTools
             AnimatorState state = layer.stateMachine.AddState("Smoother");
 
             state.motion = rootTree;
+        }
+
+        public static string NameNoSymbol(string name)
+        {
+            string nameNoSym = "";
+
+            for (int j = 0; j < name.Length; j++)
+            {
+                if (name[j] != '/')
+                {
+                    nameNoSym += name[j];
+                }
+
+            }
+            return nameNoSym;
         }
 
     }

--- a/Assets/VRCFaceTracking/Tools/Binary Parameter Tool/Editor/BinaryParameterScript.cs
+++ b/Assets/VRCFaceTracking/Tools/Binary Parameter Tool/Editor/BinaryParameterScript.cs
@@ -367,6 +367,7 @@ namespace VRCFaceTracking.EditorTools
             }
         }
 
+        // implement next update pls
         private static void CreateBranchingBinaryStatesInMachine(string name, int binarySize, AnimatorStateMachine stateMachine, AnimationClip initClip, AnimationClip finalClip, bool writeDefaults, float duration, bool nextStateInterrupt, float min, float max, AnimationClip finalNegativeClip = null, float minNeg = 0, float maxNeg = 0)
         {
             // Skips creating the negative & positive branch

--- a/Assets/VRCFaceTracking/Tools/Binary Parameter Tool/Editor/BinaryParameterWindow.cs
+++ b/Assets/VRCFaceTracking/Tools/Binary Parameter Tool/Editor/BinaryParameterWindow.cs
@@ -405,7 +405,37 @@ namespace VRCFaceTracking.EditorTools
                             "set animations, transitions, and parameters that handle the specified Binary Parameter."
                         )))
                     {
-                        if (ParameterTools.AddVRCParameter(_avDescriptor, GenerateBinaryParams(_baseParamName, _binarySize, _isCombined)) | !_createParametersInDescriptor)
+                        if (_createParametersInDescriptor)
+                        {
+                            if (ParameterTools.AddVRCParameter(_avDescriptor, GenerateBinaryParams(_baseParamName, _binarySize, _isCombined)))
+                            {
+
+                                if (_tab == 0 && !_smooth)
+                                {
+                                    ParameterTools.CheckAndCreateParameter(_baseParamName, _animatorController, 1);
+
+                                    _binaryStateMachine.initClip = BinaryParameterFloatDriver.CreateFloatDriverAnimation(_baseParamName, 0f);
+                                    _binaryStateMachine.finalClip = BinaryParameterFloatDriver.CreateFloatDriverAnimation(_baseParamName, 1f);
+                                }
+                                else if (_tab == 0)
+                                {
+                                    ParameterTools.CheckAndCreateParameter(_baseParamName, _animatorController, 1);
+
+                                    _binaryStateMachine.CreateSmoothingLayer(_smoothness);
+
+                                    _binaryStateMachine.initClip = BinaryParameterFloatDriver.CreateFloatDriverAnimation(_baseParamName + "Proxy", 0f);
+                                    _binaryStateMachine.finalClip = BinaryParameterFloatDriver.CreateFloatDriverAnimation(_baseParamName + "Proxy", 1f);
+                                }
+                                if (ParameterTools.AddVRCParameter(_avDescriptor, GenerateBinaryParams(_baseParamName, _binarySize, _isCombined)))
+                                {
+                                    ParameterTools.RemoveVRCParameter(_avDescriptor, _baseParamName);
+                                    _binaryStateMachine.CreateBinaryLayer();
+                                }
+                                else
+                                    EditorGUILayout.HelpBox("Parameters can not fit, or Expressions Parameters do not exist.", MessageType.Warning);
+                            }
+                        }
+                        else
                         {
                             if (_tab == 0 && !_smooth)
                             {
@@ -423,13 +453,7 @@ namespace VRCFaceTracking.EditorTools
                                 _binaryStateMachine.initClip = BinaryParameterFloatDriver.CreateFloatDriverAnimation(_baseParamName + "Proxy", 0f);
                                 _binaryStateMachine.finalClip = BinaryParameterFloatDriver.CreateFloatDriverAnimation(_baseParamName + "Proxy", 1f);
                             }
-                            if (ParameterTools.AddVRCParameter(_avDescriptor, GenerateBinaryParams(_baseParamName, _binarySize, _isCombined)))
-                            {
-                                ParameterTools.RemoveVRCParameter(_avDescriptor, _baseParamName);
-                                _binaryStateMachine.CreateBinaryLayer();
-                            }
-                            else
-                                EditorGUILayout.HelpBox("Parameters can not fit, or Expressions Parameters do not exist.", MessageType.Warning);
+                            _binaryStateMachine.CreateBinaryLayer();
                         }
                     }
                 }
@@ -442,15 +466,43 @@ namespace VRCFaceTracking.EditorTools
                         "set animations, transitions, and parameters that handle the specified Combined Binary Parameter."
                     )))
                 {
-                    if (ParameterTools.AddVRCParameter(_avDescriptor, GenerateBinaryParams(_baseParamName, _binarySize, _isCombined)) | !_createParametersInDescriptor)
+                    if(_createParametersInDescriptor)
+                    {
+                        if (ParameterTools.AddVRCParameter(_avDescriptor, GenerateBinaryParams(_baseParamName, _binarySize, _isCombined)))
+                        {
+                            if (_tab == 0 && !_smooth)
+                            {
+                                ParameterTools.RemoveVRCParameter(_avDescriptor, new VRCExpressionParameters.Parameter
+                                {
+                                    name = _baseParamName,
+                                    valueType = VRCExpressionParameters.ValueType.Float
+                                });
+                                ParameterTools.CheckAndCreateParameter(_baseParamName, _animatorController, 1);
+
+                                _binaryStateMachine.initClip = BinaryParameterFloatDriver.CreateFloatDriverAnimation(_baseParamName, 0f);
+                                _binaryStateMachine.finalClip = BinaryParameterFloatDriver.CreateFloatDriverAnimation(_baseParamName, 1f);
+                                _binaryStateMachine.finalNegativeClip = BinaryParameterFloatDriver.CreateFloatDriverAnimation(_baseParamName, -1f);
+                            }
+                            else if (_tab == 0)
+                            {
+                                ParameterTools.RemoveVRCParameter(_avDescriptor, _baseParamName);
+                                ParameterTools.CheckAndCreateParameter(_baseParamName, _animatorController, 1);
+
+                                _binaryStateMachine.CreateSmoothingLayer(_smoothness);
+                                _binaryStateMachine.initClip = BinaryParameterFloatDriver.CreateFloatDriverAnimation(_baseParamName + "Proxy", 0f);
+                                _binaryStateMachine.finalClip = BinaryParameterFloatDriver.CreateFloatDriverAnimation(_baseParamName + "Proxy", 1f);
+                                _binaryStateMachine.finalNegativeClip = BinaryParameterFloatDriver.CreateFloatDriverAnimation(_baseParamName + "Proxy", -1f);
+                            }
+                            _binaryStateMachine.CreateCombinedBinaryLayer();
+                        }
+                        else
+                            EditorGUILayout.HelpBox("Parameters can not fit, or Expressions Parameters do not exist.", MessageType.Warning);
+                    }
+                    else
                     {
                         if (_tab == 0 && !_smooth)
                         {
-                            ParameterTools.RemoveVRCParameter(_avDescriptor, new VRCExpressionParameters.Parameter
-                            {
-                                name = _baseParamName,
-                                valueType = VRCExpressionParameters.ValueType.Float
-                            });
+                            
                             ParameterTools.CheckAndCreateParameter(_baseParamName, _animatorController, 1);
 
                             _binaryStateMachine.initClip = BinaryParameterFloatDriver.CreateFloatDriverAnimation(_baseParamName, 0f);
@@ -458,8 +510,7 @@ namespace VRCFaceTracking.EditorTools
                             _binaryStateMachine.finalNegativeClip = BinaryParameterFloatDriver.CreateFloatDriverAnimation(_baseParamName, -1f);
                         }
                         else if (_tab == 0)
-                        {
-                            ParameterTools.RemoveVRCParameter(_avDescriptor, _baseParamName);
+                        {                           
                             ParameterTools.CheckAndCreateParameter(_baseParamName, _animatorController, 1);
 
                             _binaryStateMachine.CreateSmoothingLayer(_smoothness);
@@ -469,8 +520,7 @@ namespace VRCFaceTracking.EditorTools
                         }
                         _binaryStateMachine.CreateCombinedBinaryLayer();
                     }
-                    else
-                        EditorGUILayout.HelpBox("Parameters can not fit, or Expressions Parameters do not exist.", MessageType.Warning);
+                    
                 }
                 EditorGUILayout.HelpBox("Parameters (" + _avDescriptor.expressionParameters.CalcTotalCost() + "/" + VRCExpressionParameters.MAX_PARAMETER_COST + "):" + GenerateParamNames(_baseParamName, _binarySize, _isCombined), MessageType.None);
 

--- a/Assets/VRCFaceTracking/Tools/Binary Parameter Tool/Editor/ParameterGenerator.cs
+++ b/Assets/VRCFaceTracking/Tools/Binary Parameter Tool/Editor/ParameterGenerator.cs
@@ -132,6 +132,39 @@ namespace VRCFaceTracking.EditorTools
             return true;
         }
 
+        public static bool RemoveVRCParameter(VRCAvatarDescriptor avatarDescriptor, string parameter)
+        {
+            // Make sure Parameters aren't null
+            if (avatarDescriptor.expressionParameters == null)
+            {
+                Debug.Log("ExpressionsParameters not found!");
+                return false;
+            }
+
+            // Instantiate and Save to Database
+            VRCExpressionParameters newParameters = avatarDescriptor.expressionParameters;
+            string assetPath = AssetDatabase.GetAssetPath(avatarDescriptor.expressionParameters);
+            if (assetPath != String.Empty)
+            {
+                AssetDatabase.RemoveObjectFromAsset(avatarDescriptor.expressionParameters);
+                AssetDatabase.CreateAsset(newParameters, assetPath);
+                avatarDescriptor.expressionParameters = newParameters;
+            }
+
+            // Check and see if parameter exists
+            if (newParameters.FindParameter(parameter) != null)
+            {
+                // Remove the parameters with listed keyword
+                List<VRCExpressionParameters.Parameter> betterParametersBecauseItsAListInstead =
+                    newParameters.parameters.ToList();
+                foreach (VRCExpressionParameters.Parameter p in betterParametersBecauseItsAListInstead)
+                    if (p.name.Contains(parameter))
+                        betterParametersBecauseItsAListInstead.Remove(p);
+                newParameters.parameters = betterParametersBecauseItsAListInstead.ToArray();
+            }
+            return true;
+        }
+
         public static AnimatorControllerParameter CheckAndCreateParameter(string paramName, AnimatorController animatorController, int type, double defaultVal = 0)
         {
             AnimatorControllerParameter param = new AnimatorControllerParameter();


### PR DESCRIPTION
Added code to remove "/" in the parameter name to allow support with tiered parameters. Names with "/" will cause failure in referencing animations.

Fix create parameter option